### PR TITLE
docs: fix typo in LIMITS section (recieved -> received)

### DIFF
--- a/rest-api.md
+++ b/rest-api.md
@@ -32,7 +32,7 @@
 * The `/api/v1/exchangeInfo` `rateLimits` array contains objects related to the exchange's `REQUEST_WEIGHT` and `ORDER` rate limits.
 * A 429 will be returned when either rate limit is violated.
 * Each route has a `weight` which determines for the number of requests each endpoint counts for. Heavier endpoints and endpoints that do operations on multiple symbols will have a heavier `weight`.
-* When a 429 is recieved, it's your obligation as an API to back off and not spam the API.
+* When a 429 is received, it's your obligation as an API to back off and not spam the API.
 * **Repeatedly violating rate limits and/or failing to back off after receiving 429s will result in an automated IP ban .**
 * IP bans are tracked and **scale in duration** for repeat offenders, **from 2 minutes to 3 days**.
 


### PR DESCRIPTION
Summary: Corrects a spelling mistake in the REST API docs to improve clarity/professionalism.
Change: Updates [rest-api.md](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) in the LIMITS section, replacing “recieved” with “received”.
Scope: Docs-only; no API behavior changes.